### PR TITLE
script.js: Handle Enter event properly

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,6 +20,7 @@ $(document).ready(function(){
 	$('textarea').keypress(
     function(e){
         if (e.keyCode == 13) {
+            e.preventDefault();
             var msg = $(this).val();
 			$(this).val('');
 			if(msg!='')


### PR DESCRIPTION
Normally, a line-break was produced in the textbox every time the Enter key was pressed.
This behaviour has been prevented.

Signed-off-by: neomanu neuvine@gmail.com
